### PR TITLE
A few tweaks

### DIFF
--- a/pagerduty.pl
+++ b/pagerduty.pl
@@ -219,30 +219,33 @@ if (($nagios->{'notification'}->{'type'} eq 'PROBLEM') || ($nagios->{'notificati
 	}
 
 } elsif ($nagios->{'notification'}->{'type'} eq 'ACKNOWLEDGEMENT') {
-	$event->{'event_type'} = 'acknowledge';
+    # ignore acknowledgements originating from PagerDuty to avoid feedback loop
+    if ($nagios->{'notification'}->{'comment'} !~ / by PagerDuty\s*$/) {
+        $event->{'event_type'} = 'acknowledge';
 
-	if ($nagios->{'type'} eq 'host') {
-		$event->{'description'} =
-			$nagios->{'host'}->{'state'} .
-			' for ' .
-			$nagios->{'host'}->{'name'} .
-			' acknowledged by ' .
-			$nagios->{'notification'}->{'author'} .
-			' saying ' .
-			$nagios->{'notification'}->{'comment'};
+        if ($nagios->{'type'} eq 'host') {
+            $event->{'description'} =
+                $nagios->{'host'}->{'state'} .
+                ' for ' .
+                $nagios->{'host'}->{'name'} .
+                ' acknowledged by ' .
+                $nagios->{'notification'}->{'author'} .
+                ' saying ' .
+                $nagios->{'notification'}->{'comment'};
 
-	} elsif ($nagios->{'type'} eq 'service') {
-		$event->{'description'} =
-			$nagios->{'service'}->{'state'} .
-			' for ' .
-			($nagios->{'service'}->{'displayname'} ? $nagios->{'service'}->{'displayname'} : $nagios->{'service'}->{'desc'}) .
-			' on ' .
-			$nagios->{'host'}->{'name'} .
-			' acknowledged by ' .
-			$nagios->{'notification'}->{'author'} .
-			' saying ' .
-			$nagios->{'notification'}->{'comment'};
-	}
+        } elsif ($nagios->{'type'} eq 'service') {
+            $event->{'description'} =
+                $nagios->{'service'}->{'state'} .
+                ' for ' .
+                ($nagios->{'service'}->{'displayname'} ? $nagios->{'service'}->{'displayname'} : $nagios->{'service'}->{'desc'}) .
+                ' on ' .
+                $nagios->{'host'}->{'name'} .
+                ' acknowledged by ' .
+                $nagios->{'notification'}->{'author'} .
+                ' saying ' .
+                $nagios->{'notification'}->{'comment'};
+        }
+    }
 
 } else {
 	exit (0);

--- a/pagerduty.pl
+++ b/pagerduty.pl
@@ -220,7 +220,7 @@ if (($nagios->{'notification'}->{'type'} eq 'PROBLEM') || ($nagios->{'notificati
 
 } elsif ($nagios->{'notification'}->{'type'} eq 'ACKNOWLEDGEMENT') {
     # ignore acknowledgements originating from PagerDuty to avoid feedback loop
-    if ($nagios->{'notification'}->{'comment'} !~ / by PagerDuty\s*$/) {
+    if ($nagios->{'notification'}->{'comment'} !~ / by PagerDuty$/) {
         $event->{'event_type'} = 'acknowledge';
 
         if ($nagios->{'type'} eq 'host') {

--- a/pagerduty.pl
+++ b/pagerduty.pl
@@ -203,23 +203,19 @@ if (($nagios->{'notification'}->{'type'} eq 'PROBLEM') || ($nagios->{'notificati
 			': ' .
 			$nagios->{'host'}->{'name'} .
 			' reports ' .
-			$nagios->{'host'}->{'output'} .
-			' (' .
-			$nagios->{'host'}->{'check'}->{'command'} .
-			')';
+			$nagios->{'host'}->{'output'};
 
 	} elsif ($nagios->{'type'} eq 'service') {
 		$event->{'description'} =
 			$nagios->{'service'}->{'state'} .
 			': ' .
+			$nagios->{'service'}->{'notes'} .
+            ' ' .
 			($nagios->{'service'}->{'displayname'} ? $nagios->{'service'}->{'displayname'} : $nagios->{'service'}->{'desc'}) .
 			' on ' .
 			$nagios->{'host'}->{'name'} .
 			' reports ' .
-			$nagios->{'service'}->{'output'} .
-			' (' .
-			$nagios->{'service'}->{'check'}->{'command'} .
-			')';
+			$nagios->{'service'}->{'output'};
 	}
 
 } elsif ($nagios->{'notification'}->{'type'} eq 'ACKNOWLEDGEMENT') {


### PR DESCRIPTION
Just wanted to contribute here, feel free to reject or have me submit in separate pull requests.
1. I prefer to put Nagios service/host alerts in downtime if they're resolved in PagerDuty, so I added a config option to specify the number of seconds the downtime will last for (default's 24 hours).
2. Included the author's name in the Ack/Downtime comment.
3. Removed the check command from the PagerDuty incident.
